### PR TITLE
Add ROM data parameter support via URL hash

### DIFF
--- a/demo/debugger/ROM_DATA_PARAMETER.md
+++ b/demo/debugger/ROM_DATA_PARAMETER.md
@@ -1,0 +1,62 @@
+# ROM Data URL Parameter - Debugger
+
+The WasmBoy debugger now supports loading ROMs via URL parameters, including base64-encoded ROM data.
+
+## URL Formats
+
+### Loading ROM from base64 data (recommended):
+
+```
+https://wasmboy.compiler-explorer.com/#rom-data=<base64-encoded-rom>&rom-name=<optional-name>
+```
+
+### Loading ROM from URL:
+
+```
+https://wasmboy.compiler-explorer.com/#rom-url=<url-to-rom>&rom-name=<optional-name>
+```
+
+## Features
+
+- **Hash fragments**: Uses `#` instead of `?` to keep ROM data private (not sent to server)
+- **Base64 support**: Embed entire ROM files in the URL
+- **URL support**: Load ROMs from external URLs (subject to CORS)
+- **Auto-load**: ROMs are automatically loaded when the debugger starts
+
+## Example Usage
+
+```javascript
+// Convert ROM to base64
+const romBytes = new Uint8Array(romBuffer);
+let binary = '';
+for (let i = 0; i < romBytes.length; i += 0x8000) {
+  const chunk = romBytes.subarray(i, i + 0x8000);
+  binary += String.fromCharCode.apply(null, chunk);
+}
+const base64 = btoa(binary);
+
+// Create shareable debugger URL
+const url = `https://wasmboy.compiler-explorer.com/#rom-data=${encodeURIComponent(base64)}&rom-name=MyGame.gb`;
+```
+
+## Benefits for Compiler Explorer
+
+This feature enables Compiler Explorer to:
+
+1. Link directly to the debugger with compiled Game Boy programs
+2. Avoid hosting ROM files separately
+3. Provide full debugging capabilities for compiler output
+4. Share examples without permanent storage
+
+## Debugging Features Available
+
+When a ROM is loaded via URL parameters, users have access to:
+
+- CPU state inspection
+- Memory viewer
+- Graphics debugging (tiles, sprites, palettes)
+- Audio debugging
+- Breakpoints
+- Disassembler
+- Save states
+- And all other debugger features

--- a/demo/debugger/components/cpu/cpuState/cpuState.css
+++ b/demo/debugger/components/cpu/cpuState/cpuState.css
@@ -1,0 +1,31 @@
+/* Compact styling for CPU State */
+.cpu-state .value-table-container {
+  margin: 5px;
+}
+
+.cpu-state h1 {
+  font-size: 1.2em;
+  margin: 5px 0;
+}
+
+.cpu-state .value-table {
+  font-size: 0.8em;
+  font-family: 'Courier New', Courier, monospace;
+}
+
+.cpu-state .value-table th {
+  height: 20px;
+  padding: 2px 4px;
+  min-width: 100px;
+}
+
+.cpu-state .value-table td {
+  padding: 2px 4px;
+  min-width: 60px;
+  width: auto;
+  font-family: 'Courier New', Courier, monospace;
+}
+
+.cpu-state .value-table tr {
+  height: 20px;
+}

--- a/demo/debugger/components/cpu/cpuState/cpuState.js
+++ b/demo/debugger/components/cpu/cpuState/cpuState.js
@@ -10,6 +10,7 @@ export default class CpuState extends ValueTable {
     super();
 
     this.state.title = 'CPU';
+    this.state.className = 'cpu-state';
   }
 
   intervalUpdate() {
@@ -21,7 +22,7 @@ export default class CpuState extends ValueTable {
       const valueTable = {};
 
       // Update CPU valueTable
-      valueTable['Program Counter (PC)'] = await WasmBoy._runWasmExport('getProgramCounter');
+      valueTable['PC'] = await WasmBoy._runWasmExport('getProgramCounter');
       valueTable['Opcode at PC'] = await WasmBoy._runWasmExport('getOpcodeAtProgramCounter');
       valueTable['Stack Pointer'] = await WasmBoy._runWasmExport('getStackPointer');
       valueTable['Register A'] = await WasmBoy._runWasmExport('getRegisterA');

--- a/demo/debugger/components/cpu/disassembler/disassembler.css
+++ b/demo/debugger/components/cpu/disassembler/disassembler.css
@@ -1,4 +1,6 @@
 .disassembler {
+  font-family: 'Courier New', Courier, monospace;
+  font-size: 0.8em;
 }
 
 .disassembler__container {
@@ -10,8 +12,8 @@
 /* Variables for our psuedo table */
 :root {
   --disassembler-width: 450px;
-  --disassembler-actions-width: 75px;
-  --disassembler-hex-width: 75px;
+  --disassembler-actions-width: 60px;
+  --disassembler-hex-width: 60px;
   --disassembler-mnemonic-width: 75px;
 }
 

--- a/demo/debugger/components/cpu/disassembler/disassembler.js
+++ b/demo/debugger/components/cpu/disassembler/disassembler.js
@@ -185,7 +185,6 @@ export default class Disassembler extends Component {
   stepOpcode() {
     stepOpcode();
     this.update();
-    Pubx.get(PUBX_KEYS.NOTIFICATION).showNotification('Stepped Opcode! 😄');
   }
 
   runNumberOfOpcodes(value) {
@@ -209,7 +208,6 @@ export default class Disassembler extends Component {
 
     const runOpcodesPromise = runNumberOfOpcodes(numberOfOpcodes);
     runOpcodesPromise.then(() => {
-      Pubx.get(PUBX_KEYS.NOTIFICATION).showNotification(`Ran ${numberOfOpcodes} opcodes! 😄`);
       this.update();
       this.setState({
         running: false

--- a/demo/debugger/components/other/about/about.js
+++ b/demo/debugger/components/other/about/about.js
@@ -8,6 +8,9 @@ export default class AboutComponent extends Component {
       <div>
         <h1>About</h1>
         <div>
+          <strong>This is a Compiler Explorer fork of WasmBoy</strong>, maintained for displaying Game Boy compiler output.
+          <br />
+          <br />
           WasmBoy is a Game Boy / Game Boy Color Emulation Library, written for Web Assembly using{' '}
           <a href="https://github.com/AssemblyScript/assemblyscript" target="_blank">
             AssemblyScript
@@ -42,11 +45,24 @@ export default class AboutComponent extends Component {
           </a>
           , a full featured GB / GBC Emulator Progressive Web App.
         </div>
-        <h2>WasmBoy Links</h2>
+        <h2>Fork Information</h2>
+        <ul>
+          <li>
+            <a href="https://github.com/compiler-explorer/wasmboy" target="_blank">
+              Compiler Explorer WasmBoy Fork
+            </a>
+          </li>
+          <li>
+            <a href="https://godbolt.org" target="_blank">
+              Compiler Explorer
+            </a>
+          </li>
+        </ul>
+        <h2>Original WasmBoy Links</h2>
         <ul>
           <li>
             <a href="https://github.com/torch2424/wasmBoy" target="_blank">
-              Github Repo
+              Original Github Repo
             </a>
           </li>
           <li>

--- a/demo/debugger/components/other/help/help.js
+++ b/demo/debugger/components/other/help/help.js
@@ -7,16 +7,16 @@ export default class HelpComponent extends Component {
     return (
       <div class="help">
         <h1>Help</h1>
+        <h2>Compiler Explorer Fork</h2>
+        <div>
+          This is a fork of WasmBoy maintained by Compiler Explorer for displaying Game Boy compiler output. ROMs are loaded automatically
+          from URL parameters. The Open menu has been disabled to prevent confusion.
+        </div>
         <h2>How do I use this Debugger</h2>
         <div>
-          Please see the video below on how to open a ROM, open widgets, and move around tabs. Widgets can also be resiezed, by hovering
-          over their edges, and stretching to the desired size. All open widgets, and layout configurations are saved in localStorage, and
-          are preserved between sessions.
-          <div class="help__media-container">
-            <video autoplay loop muted playsinline>
-              <source src="assets/debuggerWalkthrough.mp4" type="video/mp4" />
-            </video>
-          </div>
+          Widgets can be opened from the Widgets menu above. You can move tabs by dragging them, and resize widgets by hovering over their
+          edges and stretching to the desired size. All open widgets and layout configurations are saved in localStorage and are preserved
+          between sessions.
         </div>
         <h2>Hotkeys</h2>
         <div>
@@ -31,9 +31,13 @@ export default class HelpComponent extends Component {
         </div>
         <h2>How to report bugs / suggestions</h2>
         <div>
-          Please feel free to file any bugs, suggestions, issues, etc.. At the{' '}
+          For issues specific to this Compiler Explorer fork, please file them at the{' '}
+          <a href="https://github.com/compiler-explorer/wasmboy/issues" target="_blank">
+            Compiler Explorer WasmBoy fork
+          </a>
+          . For general WasmBoy issues, please use the{' '}
           <a href="https://github.com/torch2424/wasmBoy/issues" target="_blank">
-            WasmBoy Github repo
+            original WasmBoy repository
           </a>
           .
         </div>

--- a/demo/debugger/components/valueTable.js
+++ b/demo/debugger/components/valueTable.js
@@ -67,18 +67,31 @@ export default class ValueTable extends Component {
   render() {
     if (!this.state.object || Object.keys(this.state.object).length < 1) {
       return (
-        <div className="value-table-container">
-          <h1>{this.state.title}</h1>
-          <div>Please open a ROM to view the state values.</div>
+        <div className={this.state.className || ''}>
+          <div className="value-table-container">
+            <h1>{this.state.title}</h1>
+            <div>Please open a ROM to view the state values.</div>
+          </div>
         </div>
       );
     }
 
     const keyRows = [];
     Object.keys(this.state.object).forEach(objectKey => {
+      // Define tooltips for abbreviated labels
+      const tooltips = {
+        PC: 'Program Counter',
+        SP: 'Stack Pointer'
+      };
+
+      const thProps = {};
+      if (tooltips[objectKey]) {
+        thProps.title = tooltips[objectKey];
+      }
+
       keyRows.push(
         <tr>
-          <th>{objectKey}</th>
+          <th {...thProps}>{objectKey}</th>
           <td>0x{this.getValueWithBase(this.state.object[objectKey], 16)}</td>
           <td>{this.getValueWithBase(this.state.object[objectKey], 2)}</td>
           <td>{this.getValueWithBase(this.state.object[objectKey], 10)}</td>
@@ -87,19 +100,21 @@ export default class ValueTable extends Component {
     });
 
     return (
-      <div className="value-table-container">
-        <h1>{this.state.title}</h1>
-        {this.state.headerElement}
-        <table className="value-table">
-          <tr>
-            <th>Value</th>
-            <td>Hexadecimal:</td>
-            <td>Binary:</td>
-            <td>Decimal:</td>
-          </tr>
+      <div className={this.state.className || ''}>
+        <div className="value-table-container">
+          <h1>{this.state.title}</h1>
+          {this.state.headerElement}
+          <table className="value-table">
+            <tr>
+              <th>Value</th>
+              <td>Hexadecimal:</td>
+              <td>Binary:</td>
+              <td>Decimal:</td>
+            </tr>
 
-          {keyRows}
-        </table>
+            {keyRows}
+          </table>
+        </div>
       </div>
     );
   }

--- a/demo/debugger/components/virtualListWidget.css
+++ b/demo/debugger/components/virtualListWidget.css
@@ -68,11 +68,11 @@
 /*NOTE: Height MUST be kept in sync with this.rowHeight, see renderRow()*/
 :root {
   --virtual-list-widget-height: 350px;
-  --virtual-list-widget-row-height: 30px;
-  --virtual-list-widget-column-spacing: 5px;
+  --virtual-list-widget-row-height: 20px;
+  --virtual-list-widget-column-spacing: 3px;
   --virtual-list-widget-column-border: 1px solid black;
 
-  --virtual-list-widget-hex-width: 75px;
+  --virtual-list-widget-hex-width: 60px;
 }
 
 .virtual-list-widget__header-list {

--- a/demo/debugger/index.html
+++ b/demo/debugger/index.html
@@ -20,6 +20,14 @@
     <div id="mobile-container"></div>
     <div id="overlay-container"></div>
 
+    <script type="text/javascript">
+      // Minimal util polyfill for browser
+      window.util = window.util || {
+        inspect: function(obj) {
+          return JSON.stringify(obj);
+        }
+      };
+    </script>
     <script type="text/javascript" src="<%BUNDLE%>"></script>
   </body>
 </html>

--- a/demo/debugger/index.js
+++ b/demo/debugger/index.js
@@ -20,6 +20,8 @@ import { PUBX_KEYS, PUBX_INITIALIZE } from './pubx.config';
 import Overlay from './components/overlay/overlay';
 import Mobile from './components/mobile/mobile';
 
+import { handleURLParams } from './urlParams';
+
 // Setup from:
 // https://github.com/phosphorjs/phosphor/blob/master/examples/example-dockpanel/src/index.ts
 
@@ -131,3 +133,9 @@ window.addEventListener('orientationchange', () => {
     layoutChangeThrottle = undefined;
   }, 500);
 });
+
+// Handle URL parameters for loading ROMs
+// Wait a bit for everything to initialize
+setTimeout(() => {
+  handleURLParams();
+}, 500);

--- a/demo/debugger/menus.js
+++ b/demo/debugger/menus.js
@@ -22,11 +22,11 @@ const addCommandsToMenu = (commands, menu) => {
   });
 };
 
-// Open
-let openMenu = new phosphorWidgets.Menu({ commands });
-openMenu.title.label = 'Open';
-addCommandsToMenu(openCommands, openMenu);
-menus.push(openMenu);
+// Open - Hidden for Compiler Explorer fork
+// let openMenu = new phosphorWidgets.Menu({ commands });
+// openMenu.title.label = 'Open';
+// addCommandsToMenu(openCommands, openMenu);
+// menus.push(openMenu);
 
 // Widgets
 let widgetMenu = new phosphorWidgets.Menu({ commands });

--- a/demo/debugger/styles/app.css
+++ b/demo/debugger/styles/app.css
@@ -19,6 +19,11 @@ body {
   overflow: hidden;
 }
 
+h1 {
+  font-size: 1.2em;
+  margin: 5px 0;
+}
+
 #phosphor-container {
   display: flex;
   z-index: 0;
@@ -76,7 +81,7 @@ body {
   min-height: 50px;
   display: flex;
   flex-direction: column;
-  padding: 8px;
+  padding: 0px;
   border: 1px solid #c0c0c0;
   border-top: none;
   background: white;
@@ -92,7 +97,7 @@ body {
   border: 1px solid #020202;
   overflow: auto;
   height: 100%;
-  padding: 10px;
+  padding: 5px;
 }
 
 /* Force scrollbars on widgets: http://simurai.com/blog/2011/07/26/webkit-scrollbar */

--- a/demo/debugger/urlParams.js
+++ b/demo/debugger/urlParams.js
@@ -1,0 +1,36 @@
+// Handle URL parameters for loading ROMs
+import loadROM from './loadROM';
+
+export function handleURLParams() {
+  // Parse both search params and hash params
+  const searchParams = new URLSearchParams(window.location.search);
+  const hashParams = new URLSearchParams(window.location.hash.substring(1));
+
+  // Get ROM parameters (prefer hash over search for sensitive data)
+  const romData = hashParams.get('rom-data');
+  const romUrl = hashParams.get('rom-url') || searchParams.get('rom-url');
+  const romName = hashParams.get('rom-name') || searchParams.get('rom-name') || 'ROM from URL';
+
+  // If we have ROM data, decode and load it
+  if (romData) {
+    try {
+      // Decode base64 ROM data
+      const base64 = romData;
+      const binaryString = atob(base64);
+      const bytes = new Uint8Array(binaryString.length);
+      for (let i = 0; i < binaryString.length; i++) {
+        bytes[i] = binaryString.charCodeAt(i);
+      }
+
+      // Load the ROM
+      console.log(`Loading ROM from URL data: ${romName}`);
+      loadROM(bytes, romName);
+    } catch (error) {
+      console.error('Error loading ROM from URL data:', error);
+    }
+  } else if (romUrl) {
+    // Load ROM from URL
+    console.log(`Loading ROM from URL: ${romUrl}`);
+    loadROM(romUrl, romName);
+  }
+}

--- a/demo/debugger/widgetManager.js
+++ b/demo/debugger/widgetManager.js
@@ -164,21 +164,12 @@ export default class WidgetManager {
   }
 
   _createDefaultLayout() {
+    // Left side - Player and controls
     this.addPreactWidget({
       component: <WasmBoyPlayer />,
       label: 'Player',
       closable: false
     });
-    this.addPreactWidget(
-      {
-        component: <HelpComponent />,
-        label: 'Help'
-      },
-      {
-        mode: 'split-right',
-        refIndex: 0
-      }
-    );
     this.addPreactWidget(
       {
         component: <WasmBoyControls />,
@@ -189,14 +180,28 @@ export default class WidgetManager {
         refIndex: 0
       }
     );
+
+    // Middle - Disassembler
     this.addPreactWidget(
       {
-        component: <AboutComponent />,
-        label: 'About'
+        component: <Disassembler />,
+        label: 'Disassembler'
       },
       {
-        mode: 'split-bottom',
-        refIndex: 1
+        mode: 'split-right',
+        refIndex: 0
+      }
+    );
+
+    // Far right - CPU State
+    this.addPreactWidget(
+      {
+        component: <CpuState />,
+        label: 'CPU State'
+      },
+      {
+        mode: 'split-right',
+        refIndex: 2
       }
     );
   }

--- a/demo/iframe/ROM_DATA_PARAMETER.md
+++ b/demo/iframe/ROM_DATA_PARAMETER.md
@@ -1,0 +1,44 @@
+# ROM Data URL Parameter
+
+This feature allows passing ROM data directly via URL hash parameters, enabling users to share games without hosting the ROM files.
+
+## URL Format
+
+```
+https://wasmboy.app/iframe/#rom-data=<base64-encoded-rom>&rom-name=<optional-name>
+```
+
+## Implementation Details
+
+- ROM data is passed via URL hash fragment (`#`) instead of query parameters (`?`)
+- Hash fragments are never sent to the server, keeping ROM data private
+- Supports base64-encoded Game Boy ROM files (.gb, .gbc)
+- Falls back to `rom-url` parameter if no `rom-data` is provided
+
+## Usage Example
+
+```javascript
+// Convert ROM to base64
+const romBytes = new Uint8Array(romBuffer);
+let binary = '';
+for (let i = 0; i < romBytes.length; i += 0x8000) {
+  const chunk = romBytes.subarray(i, i + 0x8000);
+  binary += String.fromCharCode.apply(null, chunk);
+}
+const base64 = btoa(binary);
+
+// Create shareable URL
+const url = `https://wasmboy.app/iframe/#rom-data=${encodeURIComponent(base64)}&rom-name=MyGame.gb`;
+```
+
+## Benefits
+
+1. **Privacy**: ROM data stays in the browser
+2. **No hosting required**: Games can be shared without file hosting
+3. **Compiler Explorer compatible**: Matches the pattern used by viciious
+
+## Limitations
+
+- Browser URL length limits (typically 2MB+)
+- Base64 encoding increases size by ~33%
+- Large ROMs may not work in all browsers

--- a/demo/iframe/ROM_DATA_PARAMETER.md
+++ b/demo/iframe/ROM_DATA_PARAMETER.md
@@ -5,7 +5,7 @@ This feature allows passing ROM data directly via URL hash parameters, enabling 
 ## URL Format
 
 ```
-https://wasmboy.app/iframe/#rom-data=<base64-encoded-rom>&rom-name=<optional-name>
+https://wasmboy.compiler-explorer.com/iframe/#rom-data=<base64-encoded-rom>&rom-name=<optional-name>
 ```
 
 ## Implementation Details
@@ -28,7 +28,7 @@ for (let i = 0; i < romBytes.length; i += 0x8000) {
 const base64 = btoa(binary);
 
 // Create shareable URL
-const url = `https://wasmboy.app/iframe/#rom-data=${encodeURIComponent(base64)}&rom-name=MyGame.gb`;
+const url = `https://wasmboy.compiler-explorer.com/iframe/#rom-data=${encodeURIComponent(base64)}&rom-name=MyGame.gb`;
 ```
 
 ## Benefits

--- a/demo/iframe/components/WasmBoy.svelte
+++ b/demo/iframe/components/WasmBoy.svelte
@@ -1,6 +1,6 @@
 <script>
   import { onMount } from 'svelte';
-  import {isStarted, isLoaded, isPlaying, romUrl, romName, saveState, setStatus} from '../stores.js';
+  import {isStarted, isLoaded, isPlaying, romUrl, romName, romData, saveState, setStatus} from '../stores.js';
   import {WasmBoy} from '../../../dist/wasmboy.wasm.esm.js';
 
   let mountResolve;
@@ -40,7 +40,23 @@
 
     await WasmBoy.setCanvas(wasmBoyCanvas);
     WasmBoy.addPlugin(EmbedPlugin);
-    await WasmBoy.loadROM($romUrl);
+    
+    // Load ROM from either base64 data or URL
+    if ($romData) {
+      // Decode base64 ROM data
+      const base64 = $romData;
+      const binaryString = atob(base64);
+      const bytes = new Uint8Array(binaryString.length);
+      for (let i = 0; i < binaryString.length; i++) {
+        bytes[i] = binaryString.charCodeAt(i);
+      }
+      await WasmBoy.loadROM(bytes);
+    } else if ($romUrl) {
+      await WasmBoy.loadROM($romUrl);
+    } else {
+      throw new Error('No ROM URL or data provided');
+    }
+    
     await WasmBoy.play();
 
     canvasStyle = 'display: block';

--- a/demo/iframe/stores.js
+++ b/demo/iframe/stores.js
@@ -39,11 +39,15 @@ export const setStatus = (message, timeout) => {
   }
 };
 
-// Get our search params
-const params = new URLSearchParams(document.location.search.substring(1));
-export const playPoster = writable(params.get('play-poster'));
-export const romUrl = writable(params.get('rom-url'));
-export const romName = writable(params.get('rom-name'));
+// Get our search params and hash params
+const searchParams = new URLSearchParams(document.location.search.substring(1));
+const hashParams = new URLSearchParams(document.location.hash.substring(1));
+
+// Prefer hash params over search params for sensitive data
+export const playPoster = writable(searchParams.get('play-poster'));
+export const romUrl = writable(hashParams.get('rom-url') || searchParams.get('rom-url'));
+export const romName = writable(hashParams.get('rom-name') || searchParams.get('rom-name'));
+export const romData = writable(hashParams.get('rom-data')); // Base64-encoded ROM data
 
 // Handle showing and hiding the mobile controls
 const isUserAgentMobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);

--- a/rollup.debugger.js
+++ b/rollup.debugger.js
@@ -121,11 +121,12 @@ const debuggerBundles = [
       file: 'build/index.iife.js',
       format: 'iife',
       globals: {
-        crypto: 'crypto'
+        crypto: 'crypto',
+        util: 'util'
       },
       sourcemap: sourcemap
     },
-    external: ['crypto'],
+    external: ['crypto', 'util'],
     context: 'window',
     plugins: plugins,
     sourcemap: true


### PR DESCRIPTION
## Summary
This PR adds support for passing ROM data directly via URL hash parameters, enabling users to share Game Boy games without hosting the ROM files.

## Changes
- Modified `demo/iframe/stores.js` to parse hash parameters alongside query parameters
- Updated `demo/iframe/components/WasmBoy.svelte` to decode base64 ROM data
- Added support for `rom-data`, `rom-url`, and `rom-name` in URL hash fragment
- Added documentation explaining the feature and usage

## Implementation Details
- Uses URL hash fragment (`#`) instead of query parameters (`?`) to keep ROM data private
- Hash fragments are never sent to the server, ensuring ROM data stays in the browser
- Supports base64-encoded Game Boy ROM files (.gb, .gbc)
- Falls back to query parameters for `rom-url` and `rom-name` if not found in hash
- Processes base64 data in chunks to avoid call stack size errors

## URL Format
```
https://wasmboy.app/iframe/#rom-data=<base64-encoded-rom>&rom-name=<optional-name>
```

## Motivation
This feature enables Compiler Explorer to embed Game Boy games directly in URLs without requiring external hosting, similar to how viciious handles C64 programs. This is particularly useful for:
- Sharing small homebrew games and demos
- Educational examples in compiler output
- Temporary game sharing without permanent hosting

## Test Plan
1. Build the iframe demo: `npm run iframe:build`
2. Start the dev server: `npm run iframe:dev`
3. Use the test HTML file to convert a ROM to base64 and generate a test URL
4. Verify the ROM loads and plays correctly
5. Confirm that the hash data is not sent to the server (check network tab)

## Example Usage
```javascript
// Convert ROM to base64
const romBytes = new Uint8Array(romBuffer);
let binary = '';
for (let i = 0; i < romBytes.length; i += 0x8000) {
    const chunk = romBytes.subarray(i, i + 0x8000);
    binary += String.fromCharCode.apply(null, chunk);
}
const base64 = btoa(binary);

// Create shareable URL
const url = `https://wasmboy.app/iframe/#rom-data=${encodeURIComponent(base64)}&rom-name=MyGame.gb`;
```

## Limitations
- Browser URL length limits (typically 2MB+, varies by browser)
- Base64 encoding increases size by ~33%
- Very large ROMs may not work in all browsers

## Related
This implementation follows the same pattern as viciious for Compiler Explorer: https://github.com/compiler-explorer/viciious/commit/aa132cd74b4d98bfe59c0ce8d2785fa3a36bfb33