### PR TITLE
Add S3 upload to build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,3 +58,13 @@ jobs:
       - name: Run Accuracy Tests
         run: npm run test:accuracy:nobuild
         continue-on-error: true
+
+      - name: Upload to S3
+        if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+        uses: prewk/s3-cp-action@v2
+        with:
+          source: ./build
+          dest: s3://ce-cdn.net/wasmboy
+          flags: --recursive
+          aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
## Summary
This PR adds automatic deployment of build artifacts to the Compiler Explorer CDN after successful builds on the master branch.

## Changes
- Added S3 upload step to `.github/workflows/build.yml`
- Uses `prewk/s3-cp-action@v2` (same action used by jsspeccy3)
- Uploads the `build` directory to `s3://ce-cdn.net/wasmboy`

## Configuration
- Only runs on pushes to master branch (not on pull requests)
- Requires the following GitHub secrets to be configured:
  - `AWS_ACCESS_KEY_ID`
  - `AWS_SECRET_ACCESS_KEY`

## Deployment URLs
Once deployed, the applications will be available at:
- Debugger: https://ce-cdn.net/wasmboy/
- Iframe embed: https://ce-cdn.net/wasmboy/iframe/
- Benchmark: https://ce-cdn.net/wasmboy/benchmark/

## Testing
The workflow will be tested automatically when this PR is merged to master. The S3 upload step will be skipped during the PR build since it only runs on master branch pushes.